### PR TITLE
Statistics should not be cached

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,15 @@ const stats = require("./fetchData");
 const cron = require("node-cron");
 const fs = require("fs");
 const JSON_URL = './tmp/statistics.json'
-const statistics = require(JSON_URL)
+let statistics = require(JSON_URL)
 
 //Fetch data every 10 minutes.
 cron.schedule('* 5 * * *', () => {
   stats.fetchData().then(data => {
-    try {      
+    try {
       fs.writeFileSync(JSON_URL, JSON.stringify(data));
+      delete require.cache[require.resolve(JSON_URL)];
+      statistics = require(JSON_URL)
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
Statistics was always cached to the values as when the server was started. Now it should reload each time the job runs.