### PR TITLE
Sync USA data AND add override ability for any region.

### DIFF
--- a/fetchData.js
+++ b/fetchData.js
@@ -13,9 +13,8 @@ exports.fetchAllData = async () => {
     })
     .map(region => bnoScraper.fetchData(region));
 
-
-  // TODO: Should block app boot.
-  Promise.all(bnoRegions)
+    // TODO: Refactor. Some wacky promise behavior here.
+    Promise.all(bnoRegions)
     .then(data => {
 
       // Gather BNO data as base.
@@ -56,12 +55,8 @@ exports.fetchAllData = async () => {
               allData["USA"].regions
             );
 
+            // Sync with Overrides and write final finals.
             gatherAllOverrides(allData);
-
-            // Write all JSON files.
-            Object.keys(allData).map(finalRegion => {
-              utilities.writeJSONFile(finalRegion, allData[finalRegion]);
-            });
           });
         });
     });

--- a/fetchData.js
+++ b/fetchData.js
@@ -1,12 +1,65 @@
 const globals = require("./globals");
+const utilities = require("./utilities");
 const bnoScraper = require("./micro-scrapers/bno");
+const cnnScraper = require("./micro-scrapers/cnn");
 const coronatrackerScraper = require("./micro-scrapers/coronatracker");
 
 exports.fetchAllData = async () => {
-  await bnoScraper.fetchAllData().then(data => {
-    return coronatrackerScraper.getSelectedCountries(
-      "Europe",
-      globals.countryLists["Europe"]
-    );
-  });
+  const allData = {};
+  const bnoRegions = globals.allRegions
+    .filter(region => {
+      return region.scraper === "bno";
+    })
+    .map(region => bnoScraper.fetchData(region));
+
+
+  // TODO: Should block app boot.
+  Promise.all(bnoRegions)
+    .then(data => {
+
+      // Gather BNO data as base.
+      data.map(
+        resolvedRegion => (allData[resolvedRegion.regionName] = resolvedRegion)
+      );
+    })
+    .then(() => {
+
+      // Sync coronatracker data and BNO data.
+      coronatrackerScraper
+        .getSelectedCountries("Europe", globals.countryLists["Europe"])
+        .then(europeanData => {
+          europeanData.regions,
+            (allData["Global"].regions = utilities.syncTwoRegions(
+              europeanData.regions,
+              allData["Global"].regions
+            ));
+
+          europeanData.regionTotal = utilities.calculateRegionTotal(
+            europeanData.regions
+          );
+          allData["Global"].regionTotal = utilities.calculateRegionTotal(
+            allData["Global"].regions
+          );
+        })
+        .then(() => {
+
+          // Sync USA data and CNN data.
+          cnnScraper.fetchData().then(cnnData => {
+            cnnData,
+              (allData["USA"].regions = utilities.syncTwoRegions(
+                cnnData,
+                allData["USA"].regions
+              ));
+
+            allData["USA"].regionTotal = utilities.calculateRegionTotal(
+              allData["USA"].regions
+            );
+
+            // Write all JSON files.
+            Object.keys(allData).map(finalRegion => {
+              utilities.writeJSONFile(finalRegion, allData[finalRegion]);
+            });
+          });
+        });
+    });
 };

--- a/globals.js
+++ b/globals.js
@@ -24,7 +24,7 @@ exports.allRegions = [{
     sheetName: "Canada",
     startKey: "CANADA",
     totalKey: "TOTAL",
-    scraper: ""
+    scraper: "bno"
   },
   {
     name: "Australia",

--- a/globals.js
+++ b/globals.js
@@ -10,7 +10,7 @@ exports.allRegions = [{
     sheetName: "USA",
     startKey: "UNITED STATES",
     totalKey: "U.S. TOTAL",
-    scraper: ""
+    scraper: "bno"
   },
   {
     name: "China",

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const sync = require("./syncData");
 const time = require("./getTime");
 const globals = require("./globals");
 
-//Fetch data every 10 minutes.
+// Fetch data every minute.
 cron.schedule("* * * * *", () => {
   stats.fetchAllData();
 });

--- a/micro-scrapers/bno.js
+++ b/micro-scrapers/bno.js
@@ -17,13 +17,13 @@ exports.fetchData = region => {
     return csv()
       .fromFile(utilities.getCSVPath(region.sheetName))
       .then(json => {
-         return generatedRegionalData(
+        return generatedRegionalData(
           json,
           region.startKey,
           region.totalKey,
           region.sheetName
         );
-      })
+      });
   });
 };
 
@@ -92,7 +92,7 @@ const generatedRegionalData = (data, startKey, totalKey, sheetName) => {
   sortedData.regionName = sheetName;
   sortedData.lastUpdated = time.setUpdatedTime();
 
-  if (sheetName === "LatinAmerica") {
+  if (sheetName === "LatinAmerica" && !sortedData.regions) {
     sortedData = extractCountryFromRegion("España", "LatinAmerica", sortedData);
   }
 
@@ -106,7 +106,6 @@ const extractCountryFromRegion = (country, region, data) => {
     })
     .indexOf(country);
   const targetCountry = data.regions[targetCountryIndex];
-
   data.regionTotal = {
     ...data.regionTotal,
     cases: utilities.subtractTwoValues(

--- a/micro-scrapers/bno.js
+++ b/micro-scrapers/bno.js
@@ -5,16 +5,10 @@ const time = require("../getTime");
 const utilities = require("../utilities");
 const fs = require("fs");
 
-exports.fetchAllData = async () => {
-  globals.allRegions.forEach(region => {
-    if (region.scraper === "bno") fetchData(region);
-  });
-};
-
-const fetchData = async region => {
+exports.fetchData = region => {
   return axios({
     method: "get",
-    url: utilities.getExternalCSV(region),
+    url: utilities.getExternalCSV(region.sheetName),
     responseType: "stream"
   }).then(response => {
     response.data.pipe(
@@ -23,16 +17,13 @@ const fetchData = async region => {
     return csv()
       .fromFile(utilities.getCSVPath(region.sheetName))
       .then(json => {
-        utilities.writeJSONFile(
-          region.sheetName,
-          generatedRegionalData(
-            json,
-            region.startKey,
-            region.totalKey,
-            region.sheetName
-          )
+         return generatedRegionalData(
+          json,
+          region.startKey,
+          region.totalKey,
+          region.sheetName
         );
-      });
+      })
   });
 };
 

--- a/micro-scrapers/cnn.js
+++ b/micro-scrapers/cnn.js
@@ -1,0 +1,26 @@
+const axios = require("axios");
+const fs = require("fs");
+const utilities = require("../utilities");
+
+const URL =
+  "https://ix.cnn.io/dailygraphics/graphics/20200306-us-covid19/static/js/main.chunk.js";
+const JSON_REGEX = /(?<=55\:function\(s\){s.exports=JSON.parse\(')(.*)(?='\))/g;
+
+const keyMapping = {
+  country: "name",
+  cases: "value"
+};
+
+exports.fetchData = () => {
+  return axios({
+    method: "get",
+    url: URL,
+    responseType: "text"
+  }).then(response => {
+      return extractJSON(response.data).map(state => utilities.remapKeys(state, keyMapping))
+  });
+};
+
+const extractJSON = data => {
+  return JSON.parse(data.match(JSON_REGEX)).map(region => utilities.convertAllKeysToString(region));
+};

--- a/micro-scrapers/coronatracker.js
+++ b/micro-scrapers/coronatracker.js
@@ -10,15 +10,12 @@ const keyMapping = {
   recovered: "recovered"
 };
 
-exports.getSelectedCountries = async (region, countries) => {
-  return await axios.get(`${API_ROUTE}`).then(data => {
+exports.getSelectedCountries = (region, countries) => {
+  return axios.get(`${API_ROUTE}`).then(data => {
     const allCountries = data.data;
     const filteredCountries = filterCountries(allCountries, countries);
 
-    utilities.writeJSONFile(
-      region,
-      generateRegionData(region, filteredCountries)
-    );
+    return generateRegionalData(region, filteredCountries)
   });
 };
 
@@ -31,7 +28,7 @@ const filterCountries = (allCountries, countries) => {
   );
 };
 
-const generateRegionData = (region, filteredCountries) => {
+const generateRegionalData = (region, filteredCountries) => {
   let regionTemplate = { ...globals.regionStructure };
   regionTemplate.regionName = region;
   regionTemplate.regions = filteredCountries;

--- a/overrides/statistics_Australia.json
+++ b/overrides/statistics_Australia.json
@@ -1,0 +1,126 @@
+{
+  "regions": [
+    {
+      "index": "6",
+      "country": "New South Wales",
+      "cases": "12",
+      "deaths": "2",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "7",
+      "country": "Victoria",
+      "cases": "49",
+      "deaths": "",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "8",
+      "country": "Queensland",
+      "cases": "46",
+      "deaths": "",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "9",
+      "country": "South Australia",
+      "cases": "19",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "3",
+      "mystery": "Source"
+    },
+    {
+      "index": "10",
+      "country": "Western Australia",
+      "cases": "14",
+      "deaths": "1",
+      "serious": "",
+      "critical": "",
+      "recovered": "1",
+      "mystery": "Source"
+    },
+    {
+      "index": "11",
+      "country": "Northern Territory",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "12",
+      "country": "Tasmania",
+      "cases": "5",
+      "deaths": "0",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "0",
+      "mystery": "Source"
+    },
+    {
+      "index": "13",
+      "country": "Canberra (ACT)",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "0",
+      "mystery": "Source"
+    },
+    {
+      "index": "14",
+      "country": "External territories",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "0",
+      "mystery": ""
+    },
+    {
+      "index": "15",
+      "country": "Jervis Bay Territory",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "0",
+      "mystery": ""
+    },
+    {
+      "index": "16",
+      "country": "TBD",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "23",
+      "mystery": ""
+    }
+  ],
+  "regionTotal": {
+    "index": "17",
+    "country": "TOTAL",
+    "cases": "247",
+    "deaths": "3",
+    "serious": "0",
+    "critical": "0",
+    "recovered": "27",
+    "mystery": ""
+  },
+  "regionName": "Australia",
+  "lastUpdated": "2020-03-14T16:06:00-05:00"
+}

--- a/overrides/statistics_Canada.json
+++ b/overrides/statistics_Canada.json
@@ -1,0 +1,146 @@
+{
+  "regions": [
+    {
+      "index": "6",
+      "country": "British Columbia",
+      "cases": "53",
+      "deaths": "1",
+      "serious": "",
+      "critical": "1",
+      "recovered": "6",
+      "mystery": "Source"
+    },
+    {
+      "index": "7",
+      "country": "Ontario",
+      "cases": "79",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "5",
+      "mystery": "Source"
+    },
+    {
+      "index": "8",
+      "country": "Alberta",
+      "cases": "23",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "9",
+      "country": "Quebec",
+      "cases": "17",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "10",
+      "country": "Manitoba",
+      "cases": "1",
+      "deaths": "2",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "11",
+      "country": "Saskatchewan",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "12",
+      "country": "Nova Scotia",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "13",
+      "country": "New Brunswick",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "14",
+      "country": "Newfoundland & Labrador",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "15",
+      "country": "Prince Edward Island",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "16",
+      "country": "Northwest Territories",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "17",
+      "country": "Nunavut",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "18",
+      "country": "Yukon",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    }
+  ],
+  "regionTotal": {
+    "index": "19",
+    "country": "TOTAL",
+    "cases": "176",
+    "deaths": "3",
+    "serious": "0",
+    "critical": "1",
+    "recovered": "11",
+    "mystery": ""
+  },
+  "regionName": "Canada",
+  "lastUpdated": "2020-03-13T18:53:05-07:00"
+}

--- a/overrides/statistics_China.json
+++ b/overrides/statistics_China.json
@@ -1,0 +1,96 @@
+{
+  "regions": [
+    {
+      "index": "6",
+      "country": "Hubei province (includes Wuhan)",
+      "cases": "67,790",
+      "deaths": "3,075",
+      "serious": "3,543",
+      "critical": "",
+      "recovered": "52,943",
+      "mystery": "Source"
+    },
+    {
+      "index": "7",
+      "country": "Guangdong province",
+      "cases": "1,356",
+      "deaths": "8",
+      "serious": "5",
+      "critical": "14",
+      "recovered": "1,299",
+      "mystery": "Source"
+    },
+    {
+      "index": "8",
+      "country": "Henan province",
+      "cases": "1,272",
+      "deaths": "22",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "1,249",
+      "mystery": "Source"
+    },
+    {
+      "index": "9",
+      "country": "Zhejiang province",
+      "cases": "1,227",
+      "deaths": "1",
+      "serious": "1",
+      "critical": "1",
+      "recovered": "1,211",
+      "mystery": "Source"
+    },
+    {
+      "index": "10",
+      "country": "Hunan province",
+      "cases": "1,018",
+      "deaths": "4",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "1,014",
+      "mystery": "Source"
+    },
+    {
+      "index": "11",
+      "country": "Beijing",
+      "cases": "437",
+      "deaths": "8",
+      "serious": "",
+      "critical": "",
+      "recovered": "349",
+      "mystery": "Source"
+    },
+    {
+      "index": "12",
+      "country": "Shanghai",
+      "cases": "350",
+      "deaths": "3",
+      "serious": "8",
+      "critical": "1",
+      "recovered": "324",
+      "mystery": "Source"
+    },
+    {
+      "index": "13",
+      "country": "Other regions",
+      "cases": "7,374",
+      "deaths": "68",
+      "serious": "",
+      "critical": "",
+      "recovered": "7,152",
+      "mystery": "Source"
+    }
+  ],
+  "regionTotal": {
+    "index": "14",
+    "country": "TOTAL",
+    "cases": "80,824",
+    "deaths": "3,189",
+    "serious": "3,610",
+    "critical": "",
+    "recovered": "65,541",
+    "mystery": ""
+  },
+  "regionName": "China",
+  "lastUpdated": "2020-03-14T16:06:00-05:00"
+}

--- a/overrides/statistics_Europe.json
+++ b/overrides/statistics_Europe.json
@@ -1,0 +1,277 @@
+{
+  "regionName": "Europe",
+  "regions": [
+    {
+      "country": "Italy",
+      "cases": "17,660",
+      "deaths": "1,266",
+      "recovered": "1,439",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Spain",
+      "cases": "5,232",
+      "deaths": "133",
+      "recovered": "193",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Germany",
+      "cases": "3,675",
+      "deaths": "8",
+      "recovered": "46",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "France",
+      "cases": "3,661",
+      "deaths": "79",
+      "recovered": "12",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Sweden",
+      "cases": "814",
+      "deaths": "1",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Netherlands",
+      "cases": "804",
+      "deaths": "10",
+      "recovered": "2",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Denmark",
+      "cases": "801",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "United Kingdom",
+      "cases": "798",
+      "deaths": "11",
+      "recovered": "18",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Belgium",
+      "cases": "559",
+      "deaths": "3",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Austria",
+      "cases": "504",
+      "deaths": "1",
+      "recovered": "6",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Greece",
+      "cases": "190",
+      "deaths": "1",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Finland",
+      "cases": "155",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Slovenia",
+      "cases": "141",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Czechia",
+      "cases": "141",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Portugal",
+      "cases": "112",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Ireland",
+      "cases": "90",
+      "deaths": "1",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Romania",
+      "cases": "89",
+      "deaths": "0",
+      "recovered": "7",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "San Marino",
+      "cases": "80",
+      "deaths": "5",
+      "recovered": "2",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Estonia",
+      "cases": "79",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Poland",
+      "cases": "68",
+      "deaths": "2",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Serbia",
+      "cases": "35",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Luxembourg",
+      "cases": "34",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Albania",
+      "cases": "33",
+      "deaths": "1",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Croatia",
+      "cases": "32",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Slovakia",
+      "cases": "32",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Belarus",
+      "cases": "27",
+      "deaths": "0",
+      "recovered": "3",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Bulgaria",
+      "cases": "23",
+      "deaths": "1",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Hungary",
+      "cases": "19",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Latvia",
+      "cases": "17",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Cyprus",
+      "cases": "14",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Bosnia and Herzegovina",
+      "cases": "13",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Malta",
+      "cases": "12",
+      "deaths": "0",
+      "recovered": "1",
+      "serious": "-",
+      "critical": "-"
+    },
+    {
+      "country": "Lithuania",
+      "cases": "6",
+      "deaths": "0",
+      "recovered": "0",
+      "serious": "-",
+      "critical": "-"
+    }
+  ],
+  "regionTotal": {
+    "country": "TOTAL",
+    "cases": "35,950",
+    "deaths": "1,523",
+    "recovered": "1,737",
+    "serious": "-",
+    "critical": "-"
+  }
+}

--- a/overrides/statistics_Global.json
+++ b/overrides/statistics_Global.json
@@ -1,0 +1,478 @@
+{
+  "regions": [
+    {
+      "index": "7",
+      "country": "China",
+      "cases": "80,824",
+      "deaths": "3,189",
+      "serious": "3,610",
+      "critical": "-",
+      "recovered": "65,541",
+      "mystery": "Source"
+    },
+    {
+      "country": "Italy",
+      "cases": "21",
+      "deaths": "1",
+      "serious": "1",
+      "recovered": "4",
+      "critical": "0"
+    },
+    {
+      "index": "9",
+      "country": "Iran",
+      "cases": "12,729",
+      "deaths": "611",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "4,339",
+      "mystery": "Source"
+    },
+    {
+      "index": "10",
+      "country": "South Korea",
+      "cases": "8,086",
+      "deaths": "72",
+      "serious": "-",
+      "critical": "36",
+      "recovered": "714",
+      "mystery": "Source"
+    },
+    {
+      "country": "Spain",
+      "cases": "6",
+      "deaths": "191",
+      "serious": "293",
+      "recovered": "517",
+      "critical": "0"
+    },
+    {
+      "country": "France",
+      "cases": "4",
+      "deaths": "91",
+      "serious": "154",
+      "recovered": "12",
+      "critical": "0"
+    },
+    {
+      "country": "Germany",
+      "cases": "4",
+      "deaths": "8",
+      "serious": "0",
+      "recovered": "46",
+      "critical": "2"
+    },
+    {
+      "index": "14",
+      "country": "United States",
+      "cases": "2,657",
+      "deaths": "50",
+      "serious": "-",
+      "critical": "4",
+      "recovered": "9",
+      "mystery": "Source"
+    },
+    {
+      "index": "15",
+      "country": "Switzerland",
+      "cases": "1,355",
+      "deaths": "13",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "4",
+      "mystery": "Source"
+    },
+    {
+      "country": "United Kingdom",
+      "cases": "1",
+      "deaths": "21",
+      "serious": "20",
+      "recovered": "18",
+      "critical": "0"
+    },
+    {
+      "index": "17",
+      "country": "Norway",
+      "cases": "1,042",
+      "deaths": "2",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "country": "Netherlands",
+      "cases": "959",
+      "deaths": "12",
+      "serious": "45",
+      "recovered": "2",
+      "critical": "0"
+    },
+    {
+      "country": "Sweden",
+      "cases": "948",
+      "deaths": "2",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "country": "Denmark",
+      "cases": "827",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "index": "21",
+      "country": "Japan",
+      "cases": "786",
+      "deaths": "22",
+      "serious": "32",
+      "critical": "-",
+      "recovered": "59",
+      "mystery": "Source"
+    },
+    {
+      "index": "22",
+      "country": "Diamond Princess",
+      "cases": "697",
+      "deaths": "7",
+      "serious": "14",
+      "critical": "-",
+      "recovered": "245",
+      "mystery": "Source"
+    },
+    {
+      "country": "Austria",
+      "cases": "655",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "6",
+      "critical": "0"
+    },
+    {
+      "country": "Belgium",
+      "cases": "689",
+      "deaths": "4",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "index": "25",
+      "country": "Qatar",
+      "cases": "337",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "4",
+      "mystery": "Source"
+    },
+    {
+      "index": "26",
+      "country": "Australia",
+      "cases": "247",
+      "deaths": "3",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "27",
+      "mystery": "Source"
+    },
+    {
+      "index": "27",
+      "country": "Malaysia",
+      "cases": "238",
+      "deaths": "0",
+      "serious": "5",
+      "critical": "-",
+      "recovered": "35",
+      "mystery": "Source"
+    },
+    {
+      "index": "28",
+      "country": "Canada",
+      "cases": "218",
+      "deaths": "1",
+      "serious": "-",
+      "critical": "1",
+      "recovered": "11",
+      "mystery": "Source"
+    },
+    {
+      "index": "29",
+      "country": "Singapore",
+      "cases": "212",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "14",
+      "recovered": "105",
+      "mystery": "Source"
+    },
+    {
+      "country": "Finland",
+      "cases": "223",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "index": "31",
+      "country": "Bahrain",
+      "cases": "197",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "2",
+      "recovered": "60",
+      "mystery": "Source"
+    },
+    {
+      "index": "32",
+      "country": "Hong Kong",
+      "cases": "142",
+      "deaths": "4",
+      "serious": "2",
+      "critical": "2",
+      "recovered": "81",
+      "mystery": "Source"
+    },
+    {
+      "country": "Greece",
+      "cases": "228",
+      "deaths": "3",
+      "serious": "5",
+      "recovered": "8",
+      "critical": "0"
+    },
+    {
+      "index": "34",
+      "country": "Iceland",
+      "cases": "117",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "index": "35",
+      "country": "Czech Republic",
+      "cases": "116",
+      "deaths": "0",
+      "serious": "2",
+      "critical": "0",
+      "recovered": "0",
+      "mystery": "Source"
+    },
+    {
+      "index": "36",
+      "country": "Philippines",
+      "cases": "111",
+      "deaths": "8",
+      "serious": "1",
+      "critical": "-",
+      "recovered": "2",
+      "mystery": "Source"
+    },
+    {
+      "index": "37",
+      "country": "Israel",
+      "cases": "109",
+      "deaths": "0",
+      "serious": "2",
+      "critical": "-",
+      "recovered": "3",
+      "mystery": "Source"
+    },
+    {
+      "index": "38",
+      "country": "Kuwait",
+      "cases": "100",
+      "deaths": "0",
+      "serious": "4",
+      "critical": "-",
+      "recovered": "5",
+      "mystery": "Source"
+    },
+    {
+      "country": "Slovenia",
+      "cases": "181",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "40",
+      "country": "United Arab Emirates",
+      "cases": "85",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "20",
+      "mystery": "Source"
+    },
+    {
+      "index": "41",
+      "country": "Iraq",
+      "cases": "83",
+      "deaths": "8",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "15",
+      "mystery": "Source"
+    },
+    {
+      "index": "42",
+      "country": "Egypt",
+      "cases": "80",
+      "deaths": "2",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "27",
+      "mystery": "Source"
+    },
+    {
+      "country": "Portugal",
+      "cases": "169",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "2",
+      "critical": "0"
+    },
+    {
+      "country": "San Marino",
+      "cases": "80",
+      "deaths": "5",
+      "serious": "5",
+      "recovered": "2",
+      "critical": "0"
+    },
+    {
+      "index": "45",
+      "country": "Brazil",
+      "cases": "76",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "1",
+      "mystery": "Source"
+    },
+    {
+      "index": "46",
+      "country": "Thailand",
+      "cases": "75",
+      "deaths": "1",
+      "serious": "1",
+      "critical": "-",
+      "recovered": "35",
+      "mystery": "Source"
+    },
+    {
+      "index": "47",
+      "country": "India",
+      "cases": "73",
+      "deaths": "1",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "4",
+      "mystery": "Source"
+    },
+    {
+      "country": "Ireland",
+      "cases": "129",
+      "deaths": "2",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "49",
+      "country": "Indonesia",
+      "cases": "69",
+      "deaths": "4",
+      "serious": "",
+      "critical": "",
+      "recovered": "5",
+      "mystery": "Source"
+    },
+    {
+      "index": "50",
+      "country": "Lebanon",
+      "cases": "68",
+      "deaths": "3",
+      "serious": "-",
+      "critical": "2",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "country": "Romania",
+      "cases": "116",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "9",
+      "critical": "0"
+    },
+    {
+      "country": "Poland",
+      "cases": "93",
+      "deaths": "2",
+      "serious": "2",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "53",
+      "country": "Saudi Arabia",
+      "cases": "62",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "1",
+      "mystery": "Source"
+    },
+    {
+      "index": "54",
+      "country": "Russia",
+      "cases": "59",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "3",
+      "mystery": "Source"
+    },
+    {
+      "index": "55",
+      "country": "Taiwan",
+      "cases": "50",
+      "deaths": "1",
+      "serious": "0",
+      "critical": "0",
+      "recovered": "20",
+      "mystery": "Source"
+    },
+    {
+      "index": "56",
+      "country": "Vietnam",
+      "cases": "44",
+      "deaths": "0",
+      "serious": "-",
+      "critical": "-",
+      "recovered": "16",
+      "mystery": "Source"
+    }
+  ],
+  "regionTotal": {
+    "country": "TOTAL",
+    "cases": "116,477",
+    "deaths": "4,345",
+    "recovered": "72,021",
+    "serious": "4,198",
+    "critical": "63"
+  },
+  "regionName": "Global",
+  "lastUpdated": "2020-03-14T16:06:00-05:00"
+}

--- a/overrides/statistics_LatinAmerica.json
+++ b/overrides/statistics_LatinAmerica.json
@@ -1,0 +1,166 @@
+{
+  "regions": [
+    {
+      "index": "6",
+      "country": "España",
+      "cases": "5,232",
+      "deaths": "133",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "7",
+      "country": "Brasil",
+      "cases": "98",
+      "deaths": "0",
+      "serious": "1",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "8",
+      "country": "Chile",
+      "cases": "43",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "9",
+      "country": "Costa Rica",
+      "cases": "26",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "10",
+      "country": "Argentina",
+      "cases": "21",
+      "deaths": "1",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "11",
+      "country": "Ecuador",
+      "cases": "17",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "12",
+      "country": "Peru",
+      "cases": "17",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "13",
+      "country": "Panamá",
+      "cases": "14",
+      "deaths": "1",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "14",
+      "country": "México",
+      "cases": "13",
+      "deaths": "0",
+      "serious": "1",
+      "critical": "",
+      "recovered": "4",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "15",
+      "country": "Colombia",
+      "cases": "9",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "16",
+      "country": "Rep. Dominicana",
+      "cases": "5",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "17",
+      "country": "Paraguay",
+      "cases": "5",
+      "deaths": "0",
+      "serious": "1",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "18",
+      "country": "Cuba",
+      "cases": "3",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "19",
+      "country": "Bolivia",
+      "cases": "2",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    },
+    {
+      "index": "20",
+      "country": "Honduras",
+      "cases": "2",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Fuente"
+    }
+  ],
+  "regionTotal": {
+    "index": "21",
+    "country": "TOTAL",
+    "cases": "5,507",
+    "deaths": "135",
+    "serious": "2",
+    "critical": "0",
+    "recovered": "4",
+    "mystery": ""
+  },
+  "regionName": "LatinAmerica",
+  "lastUpdated": "2020-03-14T16:06:00-05:00"
+}

--- a/overrides/statistics_USA.json
+++ b/overrides/statistics_USA.json
@@ -1,0 +1,512 @@
+{
+  "regions": [
+    {
+      "country": "Washington",
+      "cases": "0",
+      "deaths": "37",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "country": "New York",
+      "cases": "524",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "California",
+      "cases": "265",
+      "deaths": "5",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "1"
+    },
+    {
+      "country": "Massachusetts",
+      "cases": "123",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Colorado",
+      "cases": "101",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Florida",
+      "cases": "76",
+      "deaths": "2",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "New Jersey",
+      "cases": "50",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Illinois",
+      "cases": "46",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "2",
+      "critical": "0"
+    },
+    {
+      "index": "14",
+      "country": "Diamond Princess",
+      "cases": "46",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "2",
+      "mystery": "Source"
+    },
+    {
+      "country": "Georgia",
+      "cases": "66",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Pennsylvania",
+      "cases": "45",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "1"
+    },
+    {
+      "country": "Texas",
+      "cases": "39",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "1"
+    },
+    {
+      "country": "Louisiana",
+      "cases": "67",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Oregon",
+      "cases": "30",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Virginia",
+      "cases": "30",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Tennessee",
+      "cases": "32",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Michigan",
+      "cases": "25",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "23",
+      "country": "Grand Princess",
+      "cases": "21",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "country": "Wisconsin",
+      "cases": "19",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "country": "Iowa",
+      "cases": "17",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Maryland",
+      "cases": "26",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "North Carolina",
+      "cases": "23",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Kentucky",
+      "cases": "14",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Rhode Island",
+      "cases": "20",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Minnesota",
+      "cases": "21",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "1"
+    },
+    {
+      "country": "Nebraska",
+      "cases": "14",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "South Carolina",
+      "cases": "13",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Ohio",
+      "cases": "26",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Indiana",
+      "cases": "15",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Connecticut",
+      "cases": "11",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "District of Columbia",
+      "cases": "10",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "New Mexico",
+      "cases": "10",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Arizona",
+      "cases": "10",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "1",
+      "critical": "0"
+    },
+    {
+      "country": "South Dakota",
+      "cases": "9",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Arkansas",
+      "cases": "12",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "New Hampshire",
+      "cases": "7",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Utah",
+      "cases": "9",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Mississippi",
+      "cases": "6",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Kansas",
+      "cases": "7",
+      "deaths": "1",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Alabama",
+      "cases": "5",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Nevada",
+      "cases": "18",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Oklahoma",
+      "cases": "4",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Missouri",
+      "cases": "4",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Delaware",
+      "cases": "6",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Montana",
+      "cases": "5",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Puerto Rico",
+      "cases": "3",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "52",
+      "country": "Wuhan",
+      "cases": "3",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "country": "Maine",
+      "cases": "3",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Hawaii",
+      "cases": "2",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Vermont",
+      "cases": "2",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Wyoming",
+      "cases": "2",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "Alaska",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "58",
+      "country": "U.S. Virgin Islands",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": "Source"
+    },
+    {
+      "country": "Idaho",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "country": "North Dakota",
+      "cases": "1",
+      "deaths": "0",
+      "serious": "0",
+      "recovered": "0",
+      "critical": "0"
+    },
+    {
+      "index": "61",
+      "country": "West Virginia",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "62",
+      "country": "American Samoa",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "63",
+      "country": "Guam",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "64",
+      "country": "Northern Mariana Islands",
+      "cases": "0",
+      "deaths": "0",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    },
+    {
+      "index": "65",
+      "country": "TBD",
+      "cases": "328",
+      "deaths": "",
+      "serious": "",
+      "critical": "",
+      "recovered": "",
+      "mystery": ""
+    }
+  ],
+  "regionTotal": {
+    "country": "TOTAL",
+    "cases": "2,842",
+    "deaths": "50",
+    "recovered": "8",
+    "serious": "0",
+    "critical": "4"
+  },
+  "regionName": "USA",
+  "lastUpdated": "2020-03-14T16:06:00-05:00"
+}

--- a/syncData.js
+++ b/syncData.js
@@ -10,16 +10,17 @@ exports.gatherAllRegions = () => {
   ).then(values => {
     let data = {};
 
-    values.forEach(value => {
-      const regionData = JSON.parse(value);
+    values.forEach(region => {
+      const regionData = JSON.parse(region);
+      const regionName = regionData.regionName;
 
-      data[regionData.regionName] = regionData;
-      data[regionData.regionName].recoveryRate =
+      data[regionName] = regionData;
+      data[regionName].recoveryRate =
         (parseInt(
-          data[regionData.regionName].regionTotal.recovered.replace(",", "")
+          data[regionName].regionTotal.recovered.replace(",", "")
         ) /
           parseInt(
-            data[regionData.regionName].regionTotal.cases.replace(",", "")
+            data[regionName].regionTotal.cases.replace(",", "")
           )) *
         100;
     });

--- a/syncData.js
+++ b/syncData.js
@@ -24,19 +24,6 @@ exports.gatherAllRegions = () => {
         100;
     });
 
-    data["Europe"].regions,
-    data["Global"].regions = utilities.syncTwoRegions(
-        data["Europe"].regions,
-        data["Global"].regions
-    );
-
-    data["Europe"].regionTotal = utilities.calculateRegionTotal(
-      data["Europe"].regions
-    );
-    data["Global"].regionTotal = utilities.calculateRegionTotal(
-      data["Global"].regions
-    );
-
     return {
       ...data,
       allRegions: Object.keys(data)

--- a/syncData.js
+++ b/syncData.js
@@ -24,42 +24,11 @@ exports.gatherAllRegions = () => {
         100;
     });
 
-    // TODO: This should be abstracted and moved to fetchData.
-    data["Europe"].regions.map((europeanRegion, europeanIndex) => {
-      data["Global"].regions.map((globalRegion, globalIndex) => {
-        if (europeanRegion.country !== globalRegion.country) return;
-        const countryName = europeanRegion.country;
-        const europeanRegionData = europeanRegion;
-        const globalRegionData = globalRegion;
-
-        let syncRegionData = {
-          country: countryName,
-          cases:
-            globalRegionData.cases >= europeanRegionData.cases
-              ? globalRegionData.cases
-              : europeanRegionData.cases,
-          deaths:
-            globalRegionData.deaths >= europeanRegionData.deaths
-              ? globalRegionData.deaths
-              : europeanRegionData.deaths,
-          serious:
-            globalRegionData.serious >= europeanRegionData.serious
-              ? globalRegionData.serious
-              : europeanRegionData.serious,
-          recovered:
-            globalRegionData.recovered >= europeanRegionData.recovered
-              ? globalRegionData.recovered
-              : europeanRegionData.recovered,
-          critical:
-            globalRegionData.critical >= europeanRegionData.critical
-              ? globalRegionData.critical
-              : europeanRegionData.critical
-        };
-
-        data["Europe"].regions[europeanIndex] = syncRegionData;
-        data["Global"].regions[globalIndex] = syncRegionData;
-      });
-    });
+    data["Europe"].regions,
+    data["Global"].regions = utilities.syncTwoRegions(
+        data["Europe"].regions,
+        data["Global"].regions
+    );
 
     data["Europe"].regionTotal = utilities.calculateRegionTotal(
       data["Europe"].regions

--- a/utilities.js
+++ b/utilities.js
@@ -11,7 +11,7 @@ exports.getCSVPath = region => {
 
 exports.getExternalCSV = region => {
   return `https://docs.google.com/spreadsheets/d/1Hz1BO2cGOba0a8WstvMBpjPquSCCWo3u48R7zatx_A0/gviz/tq?tqx=out:csv&sheet=${
-    region.sheetName
+    region
   }`;
 };
 
@@ -31,7 +31,8 @@ exports.subtractTwoValues = (value1, value2) => {
 };
 
 exports.parseCommas = number => {
-  number = ["", " ", "-"].includes(number) ? "0" : number;
+  number = ["", " ", "-"].includes(number) ? "0" : `${number}`;
+
   return parseInt(number.replace(/,/g, ""), 10);
 };
 
@@ -88,6 +89,13 @@ exports.calculateRegionTotal = regions => {
   return regionTotalTemplate;
 };
 
+exports.getGreaterValue = (value1, value2) => {
+  if(typeof value1 === 'string') value1 = parseInt(value1)
+  if(typeof value2 === 'string') value2 = parseInt(value2)
+
+  return `${value1 >= value2 ? value1 : value2}`
+}
+
 exports.syncTwoRegions = (regions1, regions2) => {
   regions1.map((country1, country1Index) => {
     regions2.map((country2, country2Index) => {
@@ -98,26 +106,11 @@ exports.syncTwoRegions = (regions1, regions2) => {
 
       let syncRegionData = {
         country: countryName,
-        cases:
-          country2Data.cases >= country1Data.cases
-            ? country2Data.cases
-            : country1Data.cases,
-        deaths:
-          country2Data.deaths >= country1Data.deaths
-            ? country2Data.deaths
-            : country1Data.deaths,
-        serious:
-          country2Data.serious >= country1Data.serious
-            ? country2Data.serious
-            : country1Data.serious,
-        recovered:
-          country2Data.recovered >= country1Data.recovered
-            ? country2Data.recovered
-            : country1Data.recovered,
-        critical:
-          country2Data.critical >= country1Data.critical
-            ? country2Data.critical
-            : country1Data.critical
+        cases: this.getGreaterValue(country1.cases, country2.cases),
+        deaths: this.getGreaterValue(country1.deaths, country2.deaths),
+        serious: this.getGreaterValue(country1.serious, country2.serious),
+        recovered: this.getGreaterValue(country1.recovered, country2.recovered),
+        critical: this.getGreaterValue(country1.critical, country2.critical)
       };
 
       regions1[country1Index] = syncRegionData;

--- a/utilities.js
+++ b/utilities.js
@@ -87,3 +87,43 @@ exports.calculateRegionTotal = regions => {
 
   return regionTotalTemplate;
 };
+
+exports.syncTwoRegions = (regions1, regions2) => {
+  regions1.map((country1, country1Index) => {
+    regions2.map((country2, country2Index) => {
+      if (country1.country !== country2.country) return;
+      const countryName = country1.country;
+      const country1Data = country1;
+      const country2Data = country2;
+
+      let syncRegionData = {
+        country: countryName,
+        cases:
+          country2Data.cases >= country1Data.cases
+            ? country2Data.cases
+            : country1Data.cases,
+        deaths:
+          country2Data.deaths >= country1Data.deaths
+            ? country2Data.deaths
+            : country1Data.deaths,
+        serious:
+          country2Data.serious >= country1Data.serious
+            ? country2Data.serious
+            : country1Data.serious,
+        recovered:
+          country2Data.recovered >= country1Data.recovered
+            ? country2Data.recovered
+            : country1Data.recovered,
+        critical:
+          country2Data.critical >= country1Data.critical
+            ? country2Data.critical
+            : country1Data.critical
+      };
+
+      regions1[country1Index] = syncRegionData;
+      regions2[country2Index] = syncRegionData;
+    });
+  });
+
+  return regions1, regions2;
+}

--- a/utilities.js
+++ b/utilities.js
@@ -32,7 +32,6 @@ exports.subtractTwoValues = (value1, value2) => {
 
 exports.parseCommas = number => {
   number = ["", " ", "-"].includes(number) ? "0" : `${number}`;
-
   return parseInt(number.replace(/,/g, ""), 10);
 };
 
@@ -90,6 +89,9 @@ exports.calculateRegionTotal = regions => {
 };
 
 exports.getGreaterValue = (value1, value2) => {
+  value1 = ["", " ", "-"].includes(value1) ? "0" : `${value1}`;
+  value2 = ["", " ", "-"].includes(value2) ? "0" : `${value2}`;
+
   if(typeof value1 === 'string') value1 = parseInt(value1)
   if(typeof value2 === 'string') value2 = parseInt(value2)
 

--- a/utilities.js
+++ b/utilities.js
@@ -5,18 +5,20 @@ exports.getJSONPath = region => {
   return `./tmp/statistics_${region}.json`;
 };
 
+exports.getOverridesJSONPath = region => {
+  return `./overrides/statistics_${region}.json`;
+};
+
 exports.getCSVPath = region => {
   return `./tmp/data_${region}.csv`;
 };
 
 exports.getExternalCSV = region => {
-  return `https://docs.google.com/spreadsheets/d/1Hz1BO2cGOba0a8WstvMBpjPquSCCWo3u48R7zatx_A0/gviz/tq?tqx=out:csv&sheet=${
-    region
-  }`;
+  return `https://docs.google.com/spreadsheets/d/1Hz1BO2cGOba0a8WstvMBpjPquSCCWo3u48R7zatx_A0/gviz/tq?tqx=out:csv&sheet=${region}`;
 };
 
 exports.addAllNumbers = numbers => {
-  if(numbers.length === 0) return 0;
+  if (numbers.length === 0) return 0;
 
   numbers = numbers.map(number => {
     return this.parseCommas(number);
@@ -36,7 +38,7 @@ exports.parseCommas = number => {
 };
 
 exports.writeJSONFile = (region, data) => {
-  if(!data.regions.length) return
+  if (!data.regions.length) return;
   try {
     fs.writeFileSync(this.getJSONPath(region), JSON.stringify(data));
   } catch (err) {
@@ -64,7 +66,7 @@ exports.convertAllKeysToString = object => {
 };
 
 exports.calculateRegionTotal = regions => {
-  let regionTotalTemplate = {...globals.countryStructure}
+  let regionTotalTemplate = { ...globals.countryStructure };
   let allConfirmed = [];
   let allDeaths = [];
   let allRecovered = [];
@@ -92,11 +94,11 @@ exports.getGreaterValue = (value1, value2) => {
   value1 = ["", " ", "-"].includes(value1) ? "0" : `${value1}`;
   value2 = ["", " ", "-"].includes(value2) ? "0" : `${value2}`;
 
-  if(typeof value1 === 'string') value1 = parseInt(value1)
-  if(typeof value2 === 'string') value2 = parseInt(value2)
+  if (typeof value1 === "string") value1 = this.parseCommas(value1);
+  if (typeof value2 === "string") value2 = this.parseCommas(value2);
 
-  return `${value1 >= value2 ? value1 : value2}`
-}
+  return value1 >= value2 ? value1.toLocaleString() : value2.toLocaleString();
+};
 
 exports.syncTwoRegions = (regions1, regions2) => {
   regions1.map((country1, country1Index) => {
@@ -121,4 +123,4 @@ exports.syncTwoRegions = (regions1, regions2) => {
   });
 
   return regions1, regions2;
-}
+};


### PR DESCRIPTION
## Summary

This is a cool one! It will scrape for more US data. It also compares both scrapers and picks the ones with the higher values because they are likely more updated.

Sadly CNN only has confirmed cases so the other values won't be updated but it is something. We can always add in more sources.

Also I added some JSON files in `overrides/`. If something is out of date you can update these files and since it passes through the thing that grabs the highest-value source then the override will show! Once the actual source is higher then it'll use the source instead. This should make manual updates much less tedious I hope. 😅 

**There is one TODO left for this pull request!** If you think its worth it then I am hoping you could go in and update the USA or Canada or whatever override file to the one that is in production right now.

I think that is easy? It should just be grabbing the JSON files you updated on master and putting it in the overrides folder. Since you did them I just wanted you to double check that logic because maybe I am wrong or something but I think thats right.

## Easy way to test Overrides
* Start the server
* In `overrides/` Edit any country's confirmed value to something ridic like 99,999
* Don't restart the server, just wait a minute
* Refresh the page and that value should be on the page and in the table with the TOTAL row recalculated too.