### PR TITLE
Round up for recovery rate instead of down.

### DIFF
--- a/syncData.js
+++ b/syncData.js
@@ -16,13 +16,13 @@ exports.gatherAllRegions = () => {
 
       data[regionName] = regionData;
       data[regionName].recoveryRate =
-        (parseInt(
+        Math.ceil((parseInt(
           data[regionName].regionTotal.recovered.replace(",", "")
         ) /
           parseInt(
             data[regionName].regionTotal.cases.replace(",", "")
           )) *
-        100;
+        100);
     });
 
     return {

--- a/views/data.ejs
+++ b/views/data.ejs
@@ -110,7 +110,7 @@
                 </span>
                 <span class="recovery-meter">
                   <span class="recovery-meter-stat">
-                    <%= Math.ceil(data[region].recoveryRate) %>%
+                    <%= data[region].recoveryRate %>%
                   </span>
                   <span class="recovery-meter-progress" style="width: <%= data[region].recoveryRate %>%">
                     &nbsp;

--- a/views/data.ejs
+++ b/views/data.ejs
@@ -11,7 +11,7 @@
 
 
       <div class="col col-lg-3">
-        
+
         <div class="container--wrap">
           <p
             style="color: #DFDFEF; font-size: 30px; text-align: center; padding-top: 15px; font-weight: bolder; margin-bottom: 0;">
@@ -110,7 +110,7 @@
                 </span>
                 <span class="recovery-meter">
                   <span class="recovery-meter-stat">
-                    <%= Math.round(data[region].recoveryRate) %>%
+                    <%= Math.ceil(data[region].recoveryRate) %>%
                   </span>
                   <span class="recovery-meter-progress" style="width: <%= data[region].recoveryRate %>%">
                     &nbsp;


### PR DESCRIPTION
Rounding up instead of down for recovery rate so it isn't misleading by displaying 0%.