### PR TITLE
Fixed Percentage calculation

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -27,9 +27,10 @@ exports.addAllNumbers = numbers => {
 };
 
 exports.calculatePercentage = (total, amount, shouldRound = false) => {
-  let rate =
-    (parseInt(total.replace(",", "")) / parseInt(amount.replace(",", ""))) *
-    100;
+  const totalParsed = parseInt(total.replace(",", ""), 10);
+  const changeParsed = parseInt(amount.replace(",", ""), 10);
+  let rate = (changeParsed / (totalParsed - changeParsed)) * 100;
+
   if(isNaN(rate)) return 0
   rate = rate.toString();
   rate = rate.slice(0, rate.indexOf(".") + 3);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3384784/77257984-ebe56500-6c34-11ea-8d22-7e21cdfd2dd5.png)

In the image above the percentages are wrong.

You can see that it say the total confirmed cases are 38,211 and that today the change was 13.942 (36.48%). The problem with this is that this change was positive, not negative. If the starting number of cases was 38,211 and then it dropped by 13.942, then the change would be -36.48%.

However, the change was positive. The starting number 24 hours ago was 38,211 - 13,942 = 24269


13,942 is not 36.48% of 24269, it is in fact 57.45%

The correct calculation is (Change / Starting number) * 100 %
So (13.942 / 24269) = 0.5745 * 100% = 57.45%