### PR TITLE
Calculate percentage increase for cases and deaths

### DIFF
--- a/fetchData.js
+++ b/fetchData.js
@@ -68,7 +68,7 @@ const calculatePercentages = regions => {
   regions.map(region => {
     region.todayDeathRate = utilities.calculatePercentageIncrease(
       region.todayDeaths,
-      region.cases
+      region.deaths
     );
     region.todayCaseRate = utilities.calculatePercentageIncrease(
       region.todayCases,
@@ -131,7 +131,7 @@ const gatherAllOverrides = allData => {
           ),
           allSyncedData["USA"].regionTotal.todayDeathRate = utilities.calculatePercentageIncrease(
             allSyncedData["USA"].regionTotal.todayDeaths,
-            allSyncedData["USA"].regionTotal.cases
+            allSyncedData["USA"].regionTotal.deaths
           ),
           allSyncedData["USA"].regionTotal.todayCaseRate = utilities.calculatePercentageIncrease(
             allSyncedData["USA"].regionTotal.todayCases,

--- a/fetchData.js
+++ b/fetchData.js
@@ -66,11 +66,11 @@ exports.fetchAllData = async () => {
 
 const calculatePercentages = regions => {
   regions.map(region => {
-    region.todayDeathRate = utilities.calculatePercentage(
+    region.todayDeathRate = utilities.calculatePercentageIncrease(
       region.todayDeaths,
       region.cases
     );
-    region.todayCaseRate = utilities.calculatePercentage(
+    region.todayCaseRate = utilities.calculatePercentageIncrease(
       region.todayCases,
       region.cases
     );
@@ -129,11 +129,11 @@ const gatherAllOverrides = allData => {
             allSyncedData["USA"].regionTotal.cases,
             true
           ),
-          allSyncedData["USA"].regionTotal.todayDeathRate = utilities.calculatePercentage(
+          allSyncedData["USA"].regionTotal.todayDeathRate = utilities.calculatePercentageIncrease(
             allSyncedData["USA"].regionTotal.todayDeaths,
             allSyncedData["USA"].regionTotal.cases
           ),
-          allSyncedData["USA"].regionTotal.todayCaseRate = utilities.calculatePercentage(
+          allSyncedData["USA"].regionTotal.todayCaseRate = utilities.calculatePercentageIncrease(
             allSyncedData["USA"].regionTotal.todayCases,
             allSyncedData["USA"].regionTotal.cases
           )

--- a/syncData.js
+++ b/syncData.js
@@ -20,11 +20,11 @@ exports.gatherAllRegions = () => {
         data[regionName].regionTotal.cases,
         true
       ),
-      data[regionName].regionTotal.todayDeathRate = utilities.calculatePercentage(
+      data[regionName].regionTotal.todayDeathRate = utilities.calculatePercentageIncrease(
         data[regionName].regionTotal.todayDeaths,
         data[regionName].regionTotal.cases
       ),
-      data[regionName].regionTotal.todayCaseRate = utilities.calculatePercentage(
+      data[regionName].regionTotal.todayCaseRate = utilities.calculatePercentageIncrease(
         data[regionName].regionTotal.todayCases,
         data[regionName].regionTotal.cases
       )

--- a/syncData.js
+++ b/syncData.js
@@ -22,7 +22,7 @@ exports.gatherAllRegions = () => {
       ),
       data[regionName].regionTotal.todayDeathRate = utilities.calculatePercentageIncrease(
         data[regionName].regionTotal.todayDeaths,
-        data[regionName].regionTotal.cases
+        data[regionName].regionTotal.deaths
       ),
       data[regionName].regionTotal.todayCaseRate = utilities.calculatePercentageIncrease(
         data[regionName].regionTotal.todayCases,

--- a/utilities.js
+++ b/utilities.js
@@ -36,11 +36,11 @@ exports.calculatePercentage = (total, amount, shouldRound = false) => {
   return shouldRound ? Math.ceil(rate) : rate;
 };
 
-exports.calculatePercentageIncrease = (today, amount, shouldRound = false) => {
+exports.calculatePercentageIncrease = (today, total, shouldRound = false) => {
   // percent increase from yesterday = 100 * (today - yesterday) / yesterday, 
   //   where yesterday = total - today.
   let todayParsed = parseInt(today.replace(",", ""))
-  let totalParsed = parseInt(amount.replace(",", ""))
+  let totalParsed = parseInt(total.replace(",", ""))
   let yesterday = totalParsed - todayParsed
   let rate = (todayParsed - yesterday) * 100 / yesterday
   if (isNaN(rate)) return 0

--- a/utilities.js
+++ b/utilities.js
@@ -46,8 +46,8 @@ exports.calculatePercentageIncrease = (today, total, shouldRound = false) => {
   let todayParsed = parseInt(today.replace(",", ""))
   let totalParsed = parseInt(total.replace(",", ""))
   let yesterday = totalParsed - todayParsed
-  return formatRate(rate, shouldRound);
   let rate = (totalParsed - yesterday) * 100 / yesterday
+  return formatRate(rate, shouldRound);
 };
 
 exports.subtractTwoValues = (value1, value2) => {

--- a/utilities.js
+++ b/utilities.js
@@ -26,14 +26,18 @@ exports.addAllNumbers = numbers => {
   return numbers.reduce((a, b) => a + b).toLocaleString();
 };
 
+const formatRate = (rate, shouldRound=false) => {
+  if (isNaN(rate)) return 0
+  rate = rate.toString();
+  rate = rate.slice(0, rate.indexOf(".") + 3);
+  return shouldRound ? Math.ceil(rate) : rate;
+}
+
 exports.calculatePercentage = (total, amount, shouldRound = false) => {
   let rate =
     (parseInt(total.replace(",", "")) / parseInt(amount.replace(",", ""))) *
     100;
-  if(isNaN(rate)) return 0
-  rate = rate.toString();
-  rate = rate.slice(0, rate.indexOf(".") + 3);
-  return shouldRound ? Math.ceil(rate) : rate;
+  return formatRate(rate, shouldRound);
 };
 
 exports.calculatePercentageIncrease = (today, total, shouldRound = false) => {
@@ -43,10 +47,7 @@ exports.calculatePercentageIncrease = (today, total, shouldRound = false) => {
   let totalParsed = parseInt(total.replace(",", ""))
   let yesterday = totalParsed - todayParsed
   let rate = (todayParsed - yesterday) * 100 / yesterday
-  if (isNaN(rate)) return 0
-  rate = rate.toString();
-  rate = rate.slice(0, rate.indexOf(".") + 3);
-  return shouldRound ? Math.ceil(rate) : rate;
+  return formatRate(rate, shouldRound);
 };
 
 exports.subtractTwoValues = (value1, value2) => {

--- a/utilities.js
+++ b/utilities.js
@@ -46,8 +46,8 @@ exports.calculatePercentageIncrease = (today, total, shouldRound = false) => {
   let todayParsed = parseInt(today.replace(",", ""))
   let totalParsed = parseInt(total.replace(",", ""))
   let yesterday = totalParsed - todayParsed
-  let rate = (todayParsed - yesterday) * 100 / yesterday
   return formatRate(rate, shouldRound);
+  let rate = (totalParsed - yesterday) * 100 / yesterday
 };
 
 exports.subtractTwoValues = (value1, value2) => {

--- a/utilities.js
+++ b/utilities.js
@@ -36,6 +36,19 @@ exports.calculatePercentage = (total, amount, shouldRound = false) => {
   return shouldRound ? Math.ceil(rate) : rate;
 };
 
+exports.calculatePercentageIncrease = (today, amount, shouldRound = false) => {
+  // percent increase from yesterday = 100 * (today - yesterday) / yesterday, 
+  //   where yesterday = total - today.
+  let todayParsed = parseInt(today.replace(",", ""))
+  let totalParsed = parseInt(amount.replace(",", ""))
+  let yesterday = totalParsed - todayParsed
+  let rate = (todayParsed - yesterday) * 100 / yesterday
+  if (isNaN(rate)) return 0
+  rate = rate.toString();
+  rate = rate.slice(0, rate.indexOf(".") + 3);
+  return shouldRound ? Math.ceil(rate) : rate;
+};
+
 exports.subtractTwoValues = (value1, value2) => {
   return (
     this.parseCommas(value1) - (this.parseCommas(value2) || 0)


### PR DESCRIPTION
A few other PRs (#93, #94) cover this same ground. The idea is to calculate the percentage of new cases and deaths as a percentage increase from the previous day, not as a percentage of the whole. This PR preserves pct calculations where needed, such as on the progress bars.

**Example**
Today's cases: `12000`
Total cases: `22000`
Today's cases as a pct increase from yesterday: 
```
100 * (new number) / (original number)
100 * (today) / (total - today) = 
100 * 12000 / (22000 - 10000) = 
120%
```